### PR TITLE
Support empty object instead of empty array in the response body

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "samburns/request-and-response-helper",
 
-    "version": “0.3.0”,
+    "version": "0.3.0",
 
     "license": "MIT",
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "samburns/request-and-response-helper",
 
-    "version": "0.2.0",
+    "version": “0.3.0”,
 
     "license": "MIT",
 

--- a/src/SamBurns/RequestAndResponseHelper/RequestAndResponseHelper.php
+++ b/src/SamBurns/RequestAndResponseHelper/RequestAndResponseHelper.php
@@ -31,15 +31,25 @@ class RequestAndResponseHelper
     }
 
     /**
-     * Takes an array and puts JSON on the response object
+     * Takes an array and puts JSON on the response object. Optionally coerce the array into an object first
      */
-    public function responseWithJsonAdded(ResponseInterface $response, array $responseData): ResponseInterface
-    {
-        return $this->addJsonToHttpMessage($response, $responseData);
+    public function responseWithJsonAdded(
+        ResponseInterface $response,
+        array             $responseData,
+        bool              $castToObject = false
+    ): ResponseInterface {
+        return $this->addJsonToHttpMessage($response, $responseData, $castToObject);
     }
 
-    private function addJsonToHttpMessage(MessageInterface $message, array $dataToTurnIntoJson)
-    {
+    private function addJsonToHttpMessage(
+        MessageInterface $message,
+        array            $dataToTurnIntoJson,
+        bool             $castToObject = false
+    ) {
+        if ($castToObject) {
+            $dataToTurnIntoJson = (object)$dataToTurnIntoJson;
+        }
+
         $json = json_encode($dataToTurnIntoJson);
         $message->getBody()->write($json);
         return $message;


### PR DESCRIPTION
Adds an optional third parameter to responseWithJsonAdded which, when set to true causes the responseData array to be cast into an object before conversion into JSON. By default, it is false which restores the original behaviour.
